### PR TITLE
Improve exceptions by adding the server's response

### DIFF
--- a/BarnabyWalters/CardDAV/Client.php
+++ b/BarnabyWalters/CardDAV/Client.php
@@ -287,7 +287,7 @@ class Client
 			break;
 
 			default:
-				throw new Exception('Woops, something\'s gone wrong! The CardDAV server returned the http status code ' . $result['http_code'] . '.', self::EXCEPTION_WRONG_HTTP_STATUS_CODE_GET);
+				throw new Exception('Woops, something\'s gone wrong! The CardDAV server returned the http status code ' . $result['http_code'] . '. The server\'s respons was: ' . $result['response'], self::EXCEPTION_WRONG_HTTP_STATUS_CODE_GET_XML_VCARD);
 			break;
 		}
 	}
@@ -351,7 +351,7 @@ class Client
 			break;
 
 			default:
-				throw new Exception('Woops, something\'s gone wrong! The CardDAV server returned the http status code ' . $result['http_code'] . '.', self::EXCEPTION_WRONG_HTTP_STATUS_CODE_GET_XML_VCARD);
+				throw new Exception('Woops, something\'s gone wrong! The CardDAV server returned the http status code ' . $result['http_code'] . '. The server\'s respons was: ' . $result['response'], self::EXCEPTION_WRONG_HTTP_STATUS_CODE_GET_XML_VCARD);
 			break;
 		}
 	}
@@ -415,7 +415,7 @@ class Client
 			break;
 
 			default:
-				throw new Exception('Woops, something\'s gone wrong! The CardDAV server returned the http status code ' . $result['http_code'] . '.', self::EXCEPTION_WRONG_HTTP_STATUS_CODE_DELETE);
+				throw new Exception('Woops, something\'s gone wrong! The CardDAV server returned the http status code ' . $result['http_code'] . '. The server\'s respons was: ' . $result['response'], self::EXCEPTION_WRONG_HTTP_STATUS_CODE_GET_XML_VCARD);
 			break;
 		}
 	}
@@ -443,7 +443,7 @@ class Client
 			break;
 
 			default:
-				throw new Exception('Woops, something\'s gone wrong! The CardDAV server returned the http status code ' . $result['http_code'] . '.', self::EXCEPTION_WRONG_HTTP_STATUS_CODE_ADD);
+				throw new Exception('Woops, something\'s gone wrong! The CardDAV server returned the http status code ' . $result['http_code'] . '. The server\'s respons was: ' . $result['response'], self::EXCEPTION_WRONG_HTTP_STATUS_CODE_GET_XML_VCARD);
 			break;
 		}
 	}


### PR DESCRIPTION
Hey barnabywalters,
thank you for this incredibly useful script.

I'd suggest to improve the exceptions thrown if the server returns a request with an error code, by adding the server's response, because it will eventually hold some information about the occurring error.
In my case it took hours to find out the url was misspelled, what I could have found out earlier by having the server's response.

I hope you will find my changes useful.
