### PR TITLE
fix http status code for sabre servers

### DIFF
--- a/BarnabyWalters/CardDAV/Client.php
+++ b/BarnabyWalters/CardDAV/Client.php
@@ -439,6 +439,7 @@ class Client
 		switch($result['http_code'])
 		{
 			case 201:
+			case 204:
 				return $vcard_id;
 			break;
 


### PR DESCRIPTION
Sabre returns code 204 after update. So don't throw an error for 204.
https://sabre.io/dav/building-a-carddav-client/